### PR TITLE
docs: improve clarity and fix minor issues in SECURITY.md

### DIFF
--- a/SECURITY.MD
+++ b/SECURITY.MD
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This document explains the Succinct's process for handling issues reported and what to expect in return.
+This document explains Succinct's process for handling reported issues and what to expect.
 
 ## Audits
 
@@ -14,9 +14,9 @@ Security advisories for SP1 can be found [here](https://github.com/succinctlabs/
 
 ## Reporting a Security Bug
 
-All security bugs in SP1's production distribution should be reported through the SP1 Bug Bounty program on code4rena [here](https://code4rena.com/bounties/succinct). 
+All security bugs in SP1's production distribution should be reported through the SP1 Bug Bounty program on Code4rena [here](https://code4rena.com/bounties/succinct). 
 
-If you need to contact the SP1 team by email regarding security, please use the address `security@succinct.xyz`. 
+If you need to contact the SP1 team by email regarding security, please use the address `security@succinct.xyz`.
 
 ## Tracks
 
@@ -26,35 +26,35 @@ Depending on the nature of your issue, it will be categorized as an issue in the
 
 Issues in the **PUBLIC** track affect niche configurations, have very limited impact, or are already widely known.
 
-**PUBLIC** track issues are fixed on the dev branch, and get backported to the next scheduled minor releases.
+**PUBLIC** track issues are fixed on the dev branch and backported to the next scheduled minor releases.
 
 ### PRIVATE
 
 Issues in the **PRIVATE** track are violations of committed security properties.
 
-**PRIVATE** track issues are fixed in the next scheduled minor releases, and are kept private until then.
+**PRIVATE** track issues are fixed in the next scheduled minor releases and are kept private until then.
 
-Days before the release, a pre-announcement is sent to partners, announcing the presence of a security fix in the upcoming releases, and which component in SP1 is affected (but not disclosing any more details).
+Days before the release, a pre-announcement is sent to partners, indicating the presence of a security fix in the upcoming releases and which component in SP1 is affected (without disclosing detailed information).
 
 ### URGENT
 
-**URGENT** track issues are a threat to the SP1 ecosystem's integrity, or are being actively exploited in the wild leading to severe damage.
+**URGENT** track issues are a threat to SP1's ecosystem integrity or are actively exploited in the wild causing severe damage.
 
-**URGENT** track issues are fixed in private, and trigger an immediate dedicated security release, possibly with no pre-announcement.
+**URGENT** track issues are fixed in private and trigger an immediate dedicated security release, possibly with no pre-announcement.
 
 ## Disclosure Process
 
 The SP1 project uses the following disclosure process:
 
-* Once the security report is received it is assigned a primary handler. This person coordinates the fix and release process.
+* Once the security report is received, it is assigned a primary handler. This person coordinates the fix and release process.
 * The issue is confirmed and a list of affected components is determined.
 * Code is audited to find any potential similar problems.
 * Fixes are prepared for the next major and minor releases.
-* On the date that the fixes are applied, issues are disclosed as security advisories on the repository and partners are notified.
+* On the date the fixes are applied, issues are disclosed as security advisories on the repository and partners are notified.
 
-This process can take some time, especially when coordination is required with maintainers of other projects. Every effort will be made to handle the bug in as timely a manner as possible, however it's important that we follow the process described above to ensure that disclosures are handled consistently.
+This process can take some time, especially when coordination with other maintainers is needed. Every effort will be made to handle the bug as quickly as possible, but it's important to follow this process to ensure that disclosures are handled consistently.
 
-Vulnerabilities should be kept private until otherwise communicated by the Succinct team. This policy is to ensure a fix can be made in private and not be actively exploited.
+Vulnerabilities should be kept private until the Succinct team explicitly communicates otherwise.
 
 ## Acknowledgements
 


### PR DESCRIPTION
This PR improves the clarity and formatting of the `SECURITY.md` file:

- Removed incorrect usage of "the Succinct"  
- Simplified long sentences  
- Improved consistency and grammar in technical sections  
- Enhanced readability without changing any of the actual meaning  

## Motivation

Improving the `SECURITY.md` file helps contributors and users better understand the security policy.  
Some grammar and phrasing issues could lead to confusion, so this PR aims to enhance clarity.

## Solution

Corrected grammar, clarified sentences, and improved formatting.  
No actual changes were made to the meaning or intent of the document.

## PR Checklist

- [ ] Added Tests  
- [x] Added Documentation  
- [ ] Breaking changes